### PR TITLE
Added --ignore-keyboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,8 +50,8 @@ Emulating CMatrix (```unimatrix -n -s 96 -l 'o'```):
 ## Manual
 ```
 USAGE
-  unimatrix [-a] [-b] [-c COLOR] [-f] [-g COLOR] [-h] [-l CHARACTER_LIST] [-n]
-            [-o] [-s SPEED] [-u CUSTOM_CHARACTERS]
+  unimatrix [-a] [-b] [-c COLOR] [-f] [-g COLOR] [-h] [-i] [-l CHARACTER_LIST]
+            [-n] [-o] [-s SPEED] [-u CUSTOM_CHARACTERS]
 
 OPTIONAL ARGUMENTS
   -a                   Asynchronous scroll. Lines will move at varied speeds.
@@ -67,6 +67,8 @@ OPTIONAL ARGUMENTS
                        terminal's current background.
 
   -h                   Show this help message and exit
+
+  -i                   Ignore keyboard input
 
   -l CHARACTER_LIST    Select character set(s) using a string over letter
                        codes (see CHARACTER SETS below.)
@@ -87,7 +89,8 @@ OPTIONAL ARGUMENTS
 
   -w                   Single-wave mode: Does a single burst of green rain,
                        exits. You can put in a .bashrc file to run when your
-                       terminal launches. Works well with speed at 95.
+                       terminal launches. Works well with speed at 95. See -i
+                       to not block keyboard input during visual effect.
 
 LONG ARGUMENTS
   -a --asynchronous
@@ -96,6 +99,7 @@ LONG ARGUMENTS
   -f --flashers
   -g --bg-color=COLOR
   -h --help
+  -i --ignore-keyboard
   -l --character-list=CHARACTER_LIST
   -s --speed=SPEED
   -n --no-bold

--- a/unimatrix.py
+++ b/unimatrix.py
@@ -49,7 +49,7 @@ OPTIONAL ARGUMENTS
 
   -h                   Show this help message and exit
 
-  -i                   Ignore keyboard (must use with -t or -w)
+  -i                   Ignore keyboard
 
   -l CHARACTER_LIST    Select character set(s) using a string over letter
                        codes (see CHARACTER SETS below.)

--- a/unimatrix.py
+++ b/unimatrix.py
@@ -49,6 +49,8 @@ OPTIONAL ARGUMENTS
 
   -h                   Show this help message and exit
 
+  -i                   Ignore keyboard (must use with -t or -w)
+
   -l CHARACTER_LIST    Select character set(s) using a string over letter
                        codes (see CHARACTER SETS below.)
 
@@ -77,6 +79,7 @@ LONG ARGUMENTS
   -f --flashers
   -g --bg-color=COLOR
   -h --help
+  -i --ignore-keyboard
   -l --character-list=CHARACTER_LIST
   -s --speed=SPEED
   -n --no-bold
@@ -177,6 +180,9 @@ parser.add_argument('-g', '--bg-color',
                     type=str)
 parser.add_argument('-h', '--help',
                     help='display extended usage information and exit.',
+                    action='store_true')
+parser.add_argument('-i', '--ignore-keyboard',
+                    help='ignore all keyboard input.',
                     action='store_true')
 parser.add_argument('-l', '--character-list',
                     help='character set. See details below',
@@ -451,6 +457,9 @@ class KeyHandler:
         """
         Handles key presses. Returns True if a key was found, False otherwise.
         """
+        if args.ignore_keyboard:
+            return False;
+
         kp = self.screen.getch()
 
         if kp == -1:


### PR DESCRIPTION
When using `-w` in `.bashrc` file as suggested by help text for `--single-wave`, keyboard input is captured, preventing the user from starting to type a terminal command. This produces the visual effect to run on opening the terminal, but quickly becomes impractical for everyday use as the user needs to wait for it to complete before starting to type a command.

This new command line option `-i` or `--ignore-keyboard` allows the user to specify that keyboard input is ignored. Any keypresses while the script is running will be available to the terminal on exit.

Previous pull request required that `--single-save` or `--time` options be used concurrently, but this was unnecessary, as the main loop still allows `SIGINT` capture.