### PR TITLE
Minor correction in --help and readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,7 +229,7 @@ EXAMPLES
     $ unimatrix -n -s 96 -l o
 
   Use the letters from the name of your favorite operating system in bold blue:
-    $ unimatrix -B -u Linux -c blue
+    $ unimatrix -b -u Linux -c blue
 
   Use default character set, plus dollar symbol (note single quotes around
       special character):

--- a/unimatrix.py
+++ b/unimatrix.py
@@ -146,7 +146,7 @@ EXAMPLES
     $ unimatrix -n -s 96 -l o
 
   Use the letters from the name of your favorite operating system in bold blue:
-    $ unimatrix -B -u Linux -c blue
+    $ unimatrix -b -u Linux -c blue
 
   Use default character set, plus dollar symbol (note single quotes around
       special character):


### PR DESCRIPTION
**Very minor correction!** One of the examples currently instructs users to use capital -B to enable bold characters, but it doesn't work this way. It only works with lowercase -b, which this minor correction is about.