### PR TITLE
Remove unnecessary semicolon

### DIFF
--- a/unimatrix.py
+++ b/unimatrix.py
@@ -462,7 +462,7 @@ class KeyHandler:
         Handles key presses. Returns True if a key was found, False otherwise.
         """
         if args.ignore_keyboard:
-            return False;
+            return False
 
         kp = self.screen.getch()
 


### PR DESCRIPTION
pylint:
> W0301: Unnecessary semicolon (unnecessary-semicolon)

ruff:
> E703 [*] Statement ends with an unnecessary semicolon